### PR TITLE
Add global vars file

### DIFF
--- a/global_vars.py
+++ b/global_vars.py
@@ -1,0 +1,61 @@
+'''For collecting global values'''
+
+new_data = False
+
+# general
+NUM_SNPS = 36       # number of seg sites, should be divisible by 4
+L = 50000           # heuristic to get enough SNPs for simulations (50,000 or fifty-thousand)
+CHROM_RANGE = range(1,23)
+
+BATCH_SIZE = 50
+
+# util
+DEFAULT_SEED = 1833
+DEFAULT_SAMPLE_SIZE = 198
+
+# fitlering
+filter_simulated = False
+filter_real_data = False
+filter_rate = 0.50
+num_SNPs_adjusted = NUM_SNPS * 3
+
+# summary stats
+frac_test = 0.1
+COLOR_DICT = {"YRI": 'darkorange',"CEU": 'blue',"CHB": 'green', "MXL": 'red', "simulation": 'gray'}
+
+ss_labels = []
+ss_colors = []
+'''Default as CEU so that we get some color
+
+Override by commenting out the function body,
+and adding in your definitions. Leave the assert
+at the end.
+'''
+def update_ss_labels(pop_names):    
+    # ss_labels is a list of string labels, ex ["CEU", "YRI", "CHB", "simulation"]
+    # or ["msprime", "SLiM"]
+    ss_labels.extend(pop_names.split("_"))
+    ss_labels.append("simulation")
+
+    # colors for plotting, ex ["blue", "darkorange", "green", "gray"] (last is traditionally gray)
+    # ss_colors = []
+    for label in ss_labels:
+        ss_colors.append(COLOR_DICT[label])
+    
+    assert len(ss_labels) == len(ss_colors)
+'''
+Recommended:
+{new data: False, filter_simulated = False, filter_real_data = False}
+
+If you're using new data, it is recommended to filter singletons:
+{new data: True, filter_simulated = True, filter_real_data = True}
+'''
+
+if __name__ == "__main__":
+    # testing
+    print(ss_labels)
+    print(ss_colors)
+    update_ss_labels("CEU")
+    print(ss_labels)
+    print(ss_colors)
+        

--- a/real_data_random.py
+++ b/real_data_random.py
@@ -14,11 +14,8 @@ import sys
 import datetime
 
 # our imports
+import global_vars
 import util
-
-# globals
-FRAC_CALLABLE = 0.5
-L = 50000
 
 class Region:
 
@@ -32,7 +29,7 @@ class Region:
         s = str(self.chrom) + ":" + str(self.start_pos) + "-" +str(self.end_pos)
         return s
 
-    def inside_mask(self, mask_dict):
+    def inside_mask(self, mask_dict, frac_callable = 0.5):
         mask_lst = mask_dict[self.chrom] # restrict to this chrom
         region_start_idx, start_inside = binary_search(self.start_pos, mask_lst)
         region_end_idx, end_inside = binary_search(self.end_pos, mask_lst)
@@ -47,7 +44,7 @@ class Region:
                 part_inside = mask_lst[region_start_idx][1] - self.start_pos
             else:
                 part_inside = self.end_pos - mask_lst[region_start_idx][0]
-            return part_inside/self.region_len >= FRAC_CALLABLE
+            return part_inside/self.region_len >= frac_callable
 
         # different region index
         part_inside = 0
@@ -75,7 +72,7 @@ class Region:
             part_inside += (mask_lst[region_end_idx][1] - \
                 mask_lst[region_end_idx][0])
 
-        return part_inside/self.region_len >= FRAC_CALLABLE
+        return part_inside/self.region_len >= frac_callable
 
 def read_mask(filename):
     """Read from bed file"""
@@ -117,14 +114,12 @@ def binary_search(q, lst):
 
 class RealDataRandomIterator:
 
-    def __init__(self, S, filename, bed_file, frac_test=None, \
-        chrom_starts=False):
+    def __init__(self, filename, bed_file, chrom_starts=False):
         callset = h5py.File(filename, mode='r')
         print(list(callset.keys()))
         # output: ['GT'] ['CHROM', 'POS']
         print(list(callset['calldata'].keys()),list(callset['variants'].keys()))
 
-        self.S = S
         raw = callset['calldata/GT']
         print("raw", raw.shape)
         newshape = (raw.shape[0], -1)
@@ -160,7 +155,8 @@ class RealDataRandomIterator:
         while ln < region_len:
 
             if len(self.pos_all) <= i+1:
-                print("not enough on chrom", chr)
+                chr_str = chr.decode("utf-8") if isinstance(chr, bytes) else chr
+                print("not enough on chrom", chr_str)
                 return -1 # not enough on last chrom
 
             next_pos = self.pos_all[i+1]
@@ -168,7 +164,8 @@ class RealDataRandomIterator:
                 diff = next_pos - curr_pos
                 ln += diff
             else:
-                print("not enough on chrom", chr)
+                chr_str = chr.decode("utf-8") if isinstance(chr, bytes) else chr
+                print("not enough on chrom", chr_str)
                 return -1 # not enough on this chrom
             i += 1
             curr_pos = next_pos
@@ -176,35 +173,44 @@ class RealDataRandomIterator:
         return i # exclusive
 
     def real_region(self, neg1, region_len):
-        start_idx = random.randrange(self.num_snps-self.S) # inclusive
+
+        S = global_vars.NUM_SNPS if not global_vars.filter_real_data else global_vars.num_SNPs_adjusted
+        start_idx = random.randrange(self.num_snps - S) # inclusive
 
         # go by region len or by SNPs
-        if region_len:
-            end_idx = self.find_end(start_idx, L)
-            if end_idx == -1:
-                return self.real_region(neg1, region_len) # try again
-        else:
-            end_idx = start_idx + self.S # exclusive
+        end_idx_len = self.find_end(start_idx, global_vars.L)
 
-        hap_data = self.haps_all[start_idx:end_idx, :]
-        start_base = self.pos_all[start_idx]
-        end_base = self.pos_all[end_idx]
-        positions = self.pos_all[start_idx:end_idx]
+        if end_idx_len == -1:
+            return self.real_region(neg1, region_len) # try again
+
+        if region_len:
+            end_idx_S = end_idx_len
+        else:
+            end_idx_S = start_idx + S # exclusive
 
         # make sure we don't span two chroms
         start_chrom = self.chrom_all[start_idx]
-        end_chrom = self.chrom_all[end_idx-1] # inclusive here
+        end_chrom = self.chrom_all[end_idx_S-1] # inclusive here
+
         if start_chrom != end_chrom:
             #print("bad chrom", start_chrom, end_chrom)
             return self.real_region(neg1, region_len) # try again
+                                                                            
+        hap_data = self.haps_all[start_idx:end_idx_S, :]
+        start_base = self.pos_all[start_idx]
+        end_base = self.pos_all[end_idx_S]
+        end_base_len = self.pos_all[end_idx_len]
+        positions_len = self.pos_all[start_idx:end_idx_len]
+        positions_S = self.pos_all[start_idx:end_idx_S] # different if !region_len
 
-        region = Region(int(start_chrom), start_base, end_base)
+        chrom_num = int(start_chrom[3:]) if global_vars.new_data else int(start_chrom)
+        region = Region(chrom_num, start_base, end_base)
         result = region.inside_mask(self.mask_dict)
 
         # if we do have an accessible region
         if result:
-            dist_vec = [0] + [(positions[j+1] - positions[j])/L for j in \
-                range(len(positions)-1)]
+            dist_vec = [0] + [(positions_S[j+1] - positions_S[j])/global_vars.L for j in \
+                range(len(positions_S)-1)]
 
             after = util.process_gt_dist(hap_data, dist_vec, len(dist_vec), \
                 neg1=neg1)
@@ -217,7 +223,7 @@ class RealDataRandomIterator:
         """Use region_len=True for fixed region length, not by SNPs"""
 
         if not region_len:
-            regions = np.zeros((batch_size, self.num_samples, self.S, 2), \
+            regions = np.zeros((batch_size, self.num_samples, global_vars.NUM_SNPS, 2), \
                 dtype=np.float32)
 
             for i in range(batch_size):
@@ -257,7 +263,7 @@ if __name__ == "__main__":
     # test file
     filename = sys.argv[1]
     bed_file = sys.argv[2]
-    iterator = RealDataRandomIterator(S, filename, bed_file)
+    iterator = RealDataRandomIterator(filename, bed_file)
 
     start_time = datetime.datetime.now()
     for i in range(100):
@@ -269,5 +275,5 @@ if __name__ == "__main__":
 
     # test find_end
     for i in range(10):
-        start_idx = random.randrange(iterator.num_snps-iterator.S)
+        start_idx = random.randrange(iterator.num_snps-global_vars.S)
         iterator.find_end(start_idx, L)

--- a/simulation.py
+++ b/simulation.py
@@ -20,6 +20,7 @@ import sps.species
 import sps.HomSap
 
 # our imports
+import global_vars
 import real_data_random
 import util
 
@@ -29,34 +30,39 @@ import util
 
 class Generator:
 
-    def __init__(self, simulator, param_names, sample_sizes, num_snps, L, seed,\
-        mirror_real=False, reco_folder="", filter=False):
+    def __init__(self, simulator, param_names, sample_sizes, seed,\
+                 mirror_real=False, reco_folder=""):
         self.simulator = simulator
         self.param_names = param_names
         self.sample_sizes = sample_sizes
         self.num_samples = sum(sample_sizes)
-        self.num_snps = num_snps
-        self.L = L
         self.rng = default_rng(seed)
         self.curr_params = None
 
-        # for real data, use HapMap. this also turns on singleton filtering
-        self.prior = []
-        self.weights = []
-        self.filter = filter # for singletons
+        self.pretraining = False
+
+        # for real data, use HapMap
         if mirror_real and reco_folder != None:
-            files = [reco_folder + "genetic_map_GRCh37_chr" + str(i) + ".txt" \
-                for i in range(1,23)]
+            pop = reco_folder[-4: -1]
+
+            if global_vars.new_data:
+                files = [reco_folder + pop + \
+                  "_recombination_map_hapmap_format_hg38_chr_" + str(i) + \
+                  ".txt" for i in global_vars.CHROM_RANGE]
+            else:
+                files = [reco_folder + "genetic_map_GRCh37_chr" + str(i) + ".txt" \
+                   for i in global_vars.CHROM_RANGE]
+
             self.prior, self.weights = util.parse_hapmap_empirical_prior(files)
+
+        else:
+            self.prior, self.weights = [], []
 
     def simulate_batch(self, batch_size, params=[], real=False, neg1=True):
 
         # initialize 4D matrix (two channels for distances)
-        if self.num_snps == None:
-            regions = []
-        else:
-            regions = np.zeros((batch_size, self.num_samples, self.num_snps, \
-                2), dtype=np.float32) # two channels
+        regions = np.zeros((batch_size, self.num_samples, global_vars.NUM_SNPS, \
+                            2), dtype=np.float32) # two channels
 
         # set up parameters
         sim_params = util.ParamSet()
@@ -71,14 +77,9 @@ class Generator:
         for i in range(batch_size):
             seed = self.rng.integers(1,high=2**32) # like GAN "noise"
 
-            ts = self.simulator(sim_params, self.sample_sizes, self.L, seed, \
+            ts = self.simulator(sim_params, self.sample_sizes, seed, \
                                 self.get_reco(sim_params))
-            region = prep_region(ts, self.num_snps, self.L, self.filter, neg1)
-
-            if self.num_snps == None:
-                regions.append(region)
-            else:
-                regions[i] = region
+            regions[i] = prep_region(ts, neg1)
 
         return regions
 
@@ -99,24 +100,20 @@ class Generator:
 def draw_background_rate_from_prior(prior_rates, prob):
     return np.random.choice(prior_rates, p=prob)
 
-def prep_region(ts, num_snps, L, filter, neg1):
+def prep_region(ts, neg1):
     """Gets simulated data ready"""
     gt_matrix = ts.genotype_matrix().astype(float)
     snps_total = gt_matrix.shape[0]
 
     positions = [round(variant.site.position) for variant in ts.variants()]
     assert len(positions) == snps_total
-    dist_vec = [0] + [(positions[j+1] - positions[j])/L for j in \
+    dist_vec = [0] + [(positions[j+1] - positions[j])/global_vars.L for j in \
         range(snps_total-1)]
 
     # when mirroring real data
-    if filter:
-        return util.process_gt_dist(gt_matrix, dist_vec, num_snps, filter=True,\
-            rate=0.3, neg1=neg1)
-    else:
-        return util.process_gt_dist(gt_matrix, dist_vec, num_snps, neg1=neg1)
+    return util.process_gt_dist(gt_matrix, dist_vec, neg1=neg1)
 
-def simulate_im(params, sample_sizes, L, seed, reco):
+def simulate_im(params, sample_sizes, seed, reco):
     """Note this is a 2 population model"""
     assert len(sample_sizes) == 2
 
@@ -161,13 +158,13 @@ def simulate_im(params, sample_sizes, L, seed, reco):
 		population_configurations = population_configurations,
 		demographic_events = demographic_events,
 		mutation_rate = params.mut.value,
-		length = L,
+		length = global_vars.L,
 		recombination_rate = reco,
         random_seed = seed)
 
     return ts
 
-def simulate_ooa2(params, sample_sizes, L, seed, reco):
+def simulate_ooa2(params, sample_sizes,seed, reco):
     """Note this is a 2 population model"""
     assert len(sample_sizes) == 2
 
@@ -209,7 +206,7 @@ def simulate_ooa2(params, sample_sizes, L, seed, reco):
 		population_configurations = population_configurations,
 		demographic_events = demographic_events,
 		mutation_rate = params.mut.value,
-		length = L,
+		length =  global_vars.L,
 		recombination_rate = reco,
         random_seed = seed)
 
@@ -265,13 +262,13 @@ def simulate_postOOA(params, sample_sizes, L, seed, reco):
 		demographic_events = demographic_events,
         #migration_matrix = migration_matrix,
 		mutation_rate = params.mut.value,
-		length = L,
+		length =  global_vars.L,
 		recombination_rate = reco,
         random_seed = seed)
 
     return ts
 
-def simulate_exp(params, sample_sizes, L, seed, reco):
+def simulate_exp(params, sample_sizes, seed, reco):
     """Note this is a 1 population model"""
     assert len(sample_sizes) == 1
 
@@ -292,29 +289,29 @@ def simulate_exp(params, sample_sizes, L, seed, reco):
     ts = msprime.simulate(sample_size = sum(sample_sizes),
 		demographic_events = demographic_events,
 		mutation_rate = params.mut.value,
-		length = L,
+		length =  global_vars.L,
 		recombination_rate = reco,
         random_seed = seed)
 
     return ts
 
-def simulate_const(params, sample_sizes, L, seed, reco):
+def simulate_const(params, sample_sizes, seed, reco):
     assert len(sample_sizes) == 1
 
     # simulate data
     ts = msprime.simulate(sample_size=sum(sample_sizes), Ne=params.Ne.value, \
-        length=L, mutation_rate=params.mut.value, recombination_rate=reco, \
+        length=global_vars.L, mutation_rate=params.mut.value, recombination_rate=reco, \
         random_seed = seed)
 
     return ts
 
-def simulate_ooa3(params, sample_sizes, L, seed, reco):
+def simulate_ooa3(params, sample_sizes, seed, reco):
     """From OOA3 as implemented in stdpopsim"""
     assert len(sample_sizes) == 3
 
     sp = sps.species.get_species("HomSap")
 
-    mult = L/141213431 # chr9
+    mult = global_vars.L/141213431 # chr9
     contig = sp.get_contig("chr9",length_multiplier=mult) # TODO vary the chrom
 
     # 14 params

--- a/ss_helpers.py
+++ b/ss_helpers.py
@@ -15,6 +15,8 @@ import matplotlib.pyplot as plt
 import numpy as np
 import seaborn as sns
 
+import global_vars
+
 # GLOBALS
 NUM_SFS = 10
 NUM_LD  = 15
@@ -286,7 +288,7 @@ def plot_fst(ax, real_fst, sim_fst, real_label, sim_label, real_color, \
 # COLLECT STATISTICS
 ################################################################################
 
-def stats_all(matrices, matrices_region, L):
+def stats_all(matrices, matrices_region):
     """Set up and compute stats"""
 
     # sfs
@@ -330,10 +332,10 @@ def stats_all(matrices, matrices_region, L):
             pop_sfs[s].append(sfs[s])
 
         # inter-snp
-        pop_dist.extend([x*L for x in intersnp])
+        pop_dist.extend([x*global_vars.L for x in intersnp])
 
         # LD
-        ld = compute_ld(vm, L)
+        ld = compute_ld(vm, global_vars.L)
         for l in range(len(ld)):
             pop_ld[l].append(ld[l])
 


### PR DESCRIPTION
a few changes that went on in addition to global_vars.py
disc_pretraining is now called in toy trials, but only iterates through once. This is to allow all the code to be tested in toy trials.
Move process_opts out of pg_gan and summary_stats and into util. Consolidates nearly identical code, with a toggle for changes corresponding to summary_stats. This function also has a simplified way to build the population sizes array.
In real_data_random, when reading data sometimes the chrom value is a byte, and sometimes it's stored as a string. Added a line to make sure that the chrom number is always printed as a string and not a  byte.