### PR TITLE
add default sim labels for multipop models

### DIFF
--- a/global_vars.py
+++ b/global_vars.py
@@ -33,7 +33,6 @@ def update_ss_labels(pop_names, num_pops = 1):
     # SS_LABELS is a list of string labels, ex ["CEU", "YRI", "CHB", "simulation"]
     # or ["msprime", "SLiM"]
     if pop_names == "":
-        # switch
         if num_pops == 1:
             pop_labels = ["msprime"]
         else: # works for up to 7 populations

--- a/global_vars.py
+++ b/global_vars.py
@@ -16,7 +16,7 @@ FRAC_TEST = 0.1 # depricated
 # Model, params, and param_values must be defined
 OVERWRITE_TRIAL_DATA = False
 TRIAL_DATA = { 'model': 'const', 'params': 'Ne', 'data_h5': None,
-               'bed_file': None, 'reco_folder': None, 'param_values': [1000.]}
+               'bed_file': None, 'reco_folder': None, 'param_values': '10000.'}
 
 # section C: summary stats customization----------------------------------------
 COLOR_DICT = {"YRI": "darkorange","CEU": "blue","CHB": "green", "MXL": "red",
@@ -29,13 +29,28 @@ Override by commenting out the function body,
 and adding in your definitions. Leave the assert
 at the end.
 '''
-def update_ss_labels(pop_names):
+def update_ss_labels(pop_names, num_pops = 1):
     # SS_LABELS is a list of string labels, ex ["CEU", "YRI", "CHB", "simulation"]
     # or ["msprime", "SLiM"]
-    if pop_names == '':
-        pop_names = 'msprime'
+    if pop_names == "":
+        # switch
+        if num_pops == 1:
+            pop_labels = ["msprime"]
+        else: # works for up to 7 populations
+            pop_labels = [None  for i in range(num_pops)]
+            ALPHABET = "ABCDEFGHIJKLMNOPQRSTUVQXYZ"
+            ALT_COLORS = ["red", "blue", "darkorange", "green",
+                          "purple", "pink", "navy"]
 
-    SS_LABELS.extend(pop_names.split("_"))
+            for i in range(num_pops):
+                name = "POP_"+ALPHABET[i]
+                pop_labels[i] = name
+                COLOR_DICT[name] = ALT_COLORS[i]
+
+    else:
+        pop_labels = pop_names.split("_")
+
+    SS_LABELS.extend(pop_labels)
     SS_LABELS.append("simulation")
 
     # colors for plotting, ex ["blue", "darkorange", "green", "gray"] (last is traditionally gray)

--- a/summary_stats.py
+++ b/summary_stats.py
@@ -58,7 +58,7 @@ def main():
                        if opts.data_h5 is not None else ""
     # sets global_vars.SS_LABELS and global_vars.SS_COLORS
     # overwrite this function in globals.py to change
-    global_vars.update_ss_labels(pop_names)
+    global_vars.update_ss_labels(pop_names, num_pops=len(generator.sample_sizes))
 
     generator.update_params(param_values)
     print("VALUES", param_values)


### PR DESCRIPTION
tested with sim const, exp, im, & ooa3, and real data ooa3. Had to fix param values default as well to match true default.