### PR TITLE
Force region attribute types to be consistent

### DIFF
--- a/real_data_random.py
+++ b/real_data_random.py
@@ -20,10 +20,10 @@ import util
 class Region:
 
     def __init__(self, chrom, start_pos, end_pos):
-        self.chrom = chrom
-        self.start_pos = start_pos
-        self.end_pos = end_pos
-        self.region_len = end_pos - start_pos # L
+        self.chrom = str(chrom)
+        self.start_pos = int(start_pos)
+        self.end_pos = int(end_pos)
+        self.region_len = self.end_pos - self.start_pos # L
 
     def __str__(self):
         s = str(self.chrom) + ":" + str(self.start_pos) + "-" +str(self.end_pos)


### PR DESCRIPTION
This was a task I made on Feb 2 in Freedcamp, but I honestly don't remember why I felt so strongly about this other than the fact that I was getting errors, and I don't remember the circumstances, except some issues with chrom comparisons in the mask. If this change is superfluous, I don't mind throwing it out.
Thank you!